### PR TITLE
build ClojureCLR with Unity's Mono

### DIFF
--- a/unity-build.sh
+++ b/unity-build.sh
@@ -1,2 +1,21 @@
+#!/bin/bash
+
+get-unity-mono-path() {
+  case $(uname) in
+    Darwin)
+      echo /Applications/Unity/Unity.app/Contents/Mono
+      ;;
+    Linux)
+      echo /opt/Unity/Editor/Data/Mono
+      ;;
+  esac
+}
+
+
 rm -fr dist bin
-RestorePackages=false xbuild Clojure/build.proj /target:"Dist" /p:Runtime="Mono" /p:Configuration="Release 3.5" /p:Platform="Any CPU"
+export UNITY_MONO=${UNITY_MONO:-$(get-unity-mono-path)}
+export PATH=$UNITY_MONO/bin:$PATH
+export MONO_PATH=$UNITY_MONO/lib/mono/2.0
+
+RestorePackages=false xbuild Clojure/build.proj /target:"Build" /p:Runtime="Mono" /p:Configuration="Release 3.5" /p:Platform="Any CPU"
+


### PR DESCRIPTION
You can override Unity's Mono path by setting the `UNITY_MONO` env var:

    UNITY_MONO=/some/path ./unity-build.sh

If `UNITY_MONO` is not set, the script sets a default value  depending on your `uname`.